### PR TITLE
Use timedelta to check for expiration

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,13 +15,29 @@ from tokman.app import Token
         (Token(expires_at=datetime.utcnow() + timedelta(minutes=10), token=None), True),
         (
             Token(
-                expires_at=datetime.utcnow() + timedelta(minutes=10), token="Token123",
+                expires_at=datetime.utcnow() + timedelta(minutes=10),
+                token="Token123",
             ),
             False,
         ),
         (
             Token(
-                expires_at=datetime.utcnow() + timedelta(seconds=10), token="Token123",
+                expires_at=datetime.utcnow() + timedelta(seconds=10),
+                token="Token123",
+            ),
+            True,
+        ),
+        (
+            Token(
+                expires_at=datetime.utcnow() - timedelta(seconds=10),
+                token="Token123",
+            ),
+            True,
+        ),
+        (
+            Token(
+                expires_at=datetime.utcnow() - timedelta(minutes=10),
+                token="Token123",
             ),
             True,
         ),

--- a/tokman/app.py
+++ b/tokman/app.py
@@ -4,7 +4,7 @@
 import logging
 import os
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from flask import Flask, current_app
 from flask_sqlalchemy import SQLAlchemy
@@ -70,11 +70,13 @@ class Token(db.Model):
     expires_at = db.Column(db.DateTime, nullable=True)
 
     def is_expired(self):
-        token_renew_at = int(current_app.config.get("TOKEN_RENEW_AT", 60))
+        token_renew_at = timedelta(
+            seconds=int(current_app.config.get("TOKEN_RENEW_AT", 60))
+        )
         return (
             self.expires_at is None
             or self.token is None
-            or (self.expires_at - datetime.utcnow()).seconds < token_renew_at
+            or (self.expires_at - datetime.utcnow()) < token_renew_at
         )
 
 


### PR DESCRIPTION
'seconds' in a timedelta object are always positive, so it was not the
best idea to use it to check whether tokens have expired, as tokens
expired longer than the renewal interval are never found to be expired.

Fix this by making the renewal interval a timedelta and compare it with
the timedelta between the expiration time and the current time.

Add two new tests to cover the case when tokens are already expired.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>