### PR TITLE
Update pre-commit configuration for prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,8 @@ repos:
     hooks:
       - id: black
         language_version: python3.6
-  - repo: https://github.com/prettier/prettier
-    rev: 2.0.5
+  - repo: https://github.com/prettier/pre-commit
+    rev: v2.1.2
     hooks:
       - id: prettier
         exclude: tests_requre/openshift_integration/test_data/*


### PR DESCRIPTION
In order to solve this installation issue:

https://github.com/prettier/prettier/issues/9459

It seems that prettier is moving the pre-commit parts in a separate
repository.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>