### PR TITLE
Make 'make check' more consistent across projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing Guidelines
+
+Please follow common guidelines for our projects [here](https://github.com/packit/contributing).
+
+---
+
+## Please refer to README.md for complete information on running and developing tokman.
+
+Thank you for your interest!

--- a/Containerfile.tests
+++ b/Containerfile.tests
@@ -1,0 +1,13 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+FROM tokman
+
+WORKDIR /src
+
+RUN dnf install -y \
+    findutils \
+    make \
+    python3-flexmock \
+    python3-pytest \
+    && dnf clean all

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-.PHONY: build re-build
+.PHONY: build-image rebuild-image build-test-image rebuild-test-image
 
 IMAGE_NAME ?= tokman
+TEST_IMAGE ?= tokman-test
 WORKERS ?= 1
 LOG_LEVEL ?= info
 CONTAINER_ENGINE ?= $(shell command -v podman 2> /dev/null || echo docker)
@@ -15,12 +16,21 @@ TESTING_CONFIG := $(CURDIR)/tests/data/testing_config.py
 build:
 	$(CONTAINER_ENGINE) build -f Containerfile -t $(IMAGE_NAME) .
 
-re-build:
+rebuild:
 	$(CONTAINER_ENGINE) build --no-cache --pull=true -f Containerfile -t $(IMAGE_NAME) .
 
 run:
-	$(CONTAINER_ENGINE) run -it --rm -v $(CURDIR):/config:z -v $(SECRETS_DIR):/secrets:z --env TOKMAN_CONFIG=/config/config.py --env WORKERS=$(WORKERS) --env LOG_LEVEL=$(LOG_LEVEL) --publish 8000 tokman
+	$(CONTAINER_ENGINE) run -it --rm -v $(CURDIR):/config:z -v $(SECRETS_DIR):/secrets:z --env TOKMAN_CONFIG=/config/config.py --env WORKERS=$(WORKERS) --env LOG_LEVEL=$(LOG_LEVEL) --publish 8000 $(IMAGE_NAME)
+
+build-test-image: build
+	$(CONTAINER_ENGINE) build -f Containerfile.tests -t $(TEST_IMAGE) .
+
+rebuild-test-image: rebuild
+	$(CONTAINER_ENGINE) build --no-cache -f Containerfile.tests -t $(TEST_IMAGE) .
 
 check:
 	find . -name "*.pyc" -exec rm {} \;
 	TOKMAN_CONFIG=$(TESTING_CONFIG) PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 python3 -m pytest --verbose --showlocals  $(TEST_TARGET)
+
+check-in-container:
+	$(CONTAINER_ENGINE) run --rm -it -v $(CURDIR):/src:Z -w /src $(TEST_IMAGE) make check

--- a/README.md
+++ b/README.md
@@ -56,8 +56,16 @@ GET <tokman_url>/api/<namespace>/<repository>
 
 `make build` builds the image.
 
-`make re-build` builds the image ignoring any cache and making sure the latest
-base image pulled.
+`make rebuild` builds the image ignoring any cache and making sure
+the latest base image is pulled.
+
+`make build-test-image` builds the image.
+
+`make rebuild-test-image` builds the image ignoring any cache and making sure
+the latest base image is pulled.
+
+`make check-in-container` runs tests in a container.
+`make check` runs the same tests locally.
 
 Before running the app locally, make sure you create `config.py` by making a
 copy of `config.py.example`. Update the value of `GITHUB_APP_ID` with the


### PR DESCRIPTION
Makefile:
build, re-build => build-test-image, rebuild-test-image
Add check-in-container target.

Containerfile:
install findutils, make, python3-flexmock, python3-pytest

README.md:
build, re-build => build-test-image, rebuild-test-image
Add description of 'make check' & 'make check-in-container'

Add CONTRIBUTING.md stub with pointer back to README.md.

Signed-off-by: Ben Crocker <bcrocker@redhat.com>