### PR TITLE
Switch from git:// to https:// for rebase hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,5 +40,5 @@ repos:
     hooks:
       - id: check-rebase
         args:
-          - git://github.com/packit/tokman.git
+          - https://github.com/packit/tokman.git
         stages: [manual, push]


### PR DESCRIPTION
Starting from March 15, Github no longer supports unauthenticated access
using git:// protocol [1]. For our use-case inside rebase pre-commit
hook, switching to https:// over git:// shouldn't have any consequences.

[1] https://github.blog/2021-09-01-improving-git-protocol-security-github/

Signed-off-by: František Nečas <fnecas@redhat.com>

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

<!-- release notes for changelog/blog follow -->
