### PR TITLE
Install python3-packaging in the tokman image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,6 +3,9 @@
 
 FROM fedora:35
 
+# Dependency of setupcfg2rpm
+RUN dnf install -y python3-packaging && dnf clean all
+
 WORKDIR /tokman
 ADD https://raw.githubusercontent.com/packit/deployment/master/scripts/setupcfg2rpm.py /tokman/setupcfg2rpm.py
 COPY setup.cfg /tokman/


### PR DESCRIPTION
It's going to be required by setupcfg2rpm in order to be interpret
markers. See packit/deployment#324.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>