### PR TITLE
Run gunicorn with Python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
     rev: v2.7.1
     hooks:
       - id: prettier
-        exclude: tests_requre/openshift_integration/test_data/*
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-.PHONY: build-image rebuild-image build-test-image rebuild-test-image
+.PHONY: build-image rebuild build-test-image rebuild-test-image
 
 IMAGE_NAME ?= tokman
 TEST_IMAGE ?= tokman-test
@@ -20,7 +20,15 @@ rebuild:
 	$(CONTAINER_ENGINE) build --no-cache --pull=true -f Containerfile -t $(IMAGE_NAME) .
 
 run:
-	$(CONTAINER_ENGINE) run -it --rm -v $(CURDIR):/config:z -v $(SECRETS_DIR):/secrets:z --env TOKMAN_CONFIG=/config/config.py --env WORKERS=$(WORKERS) --env LOG_LEVEL=$(LOG_LEVEL) --publish 8000 $(IMAGE_NAME)
+	$(CONTAINER_ENGINE) run -it --rm \
+		-v $(CURDIR):/config:z \
+		-v $(SECRETS_DIR):/secrets:z \
+		-v $(CURDIR):/access_tokens:z \
+		--env TOKMAN_CONFIG=/config/config.py \
+		--env WORKERS=$(WORKERS) \
+		--env LOG_LEVEL=$(LOG_LEVEL) \
+		--network=host \
+		$(IMAGE_NAME)
 
 build-test-image: build
 	$(CONTAINER_ENGINE) build -f Containerfile.tests -t $(TEST_IMAGE) .

--- a/run.sh
+++ b/run.sh
@@ -7,4 +7,4 @@ set -eux
 
 alembic-3 upgrade head
 sleep 1
-gunicorn -w ${WORKERS:-1} --log-level ${LOG_LEVEL:-info} --bind ${BIND_ADDR:-127.0.0.1:8000} tokman
+python3 -m gunicorn.app.wsgiapp -w ${WORKERS:-1} --log-level ${LOG_LEVEL:-info} --bind ${BIND_ADDR:-127.0.0.1:8000} tokman


### PR DESCRIPTION
Instead of calling 'gunicorn', run it through Python.

Do this, b/c the entrypoint script installed by gunicorns RPM package,
uses the '-s' flag for the Python interpreter and so it doesn't add to
'sys.path' the user site directory, which causes modules installed with
'pip' (like sentry-sdk) not to be found.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>