### PR TITLE
Use environment files instead of set-output command

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -17,7 +17,7 @@ jobs:
             image: tokman
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Extract branch name and set tag
         shell: bash
@@ -32,9 +32,9 @@ jobs:
                   tag="prod"
                   ;;
           esac
-          echo "::set-output name=branch::${branch}"
+          echo "branch=${branch}" >> $GITHUB_OUTPUT
           unique_tag="${branch}-${GITHUB_SHA::7}"
-          echo "::set-output name=tag::${tag} ${unique_tag}"
+          echo "tag=${tag} ${unique_tag}" >> $GITHUB_OUTPUT
         id: branch_tag
 
       - name: Build Image

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,26 +4,30 @@
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.10.0
     hooks:
       - id: black
-        language_version: python3.6
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
+      - id: check-builtin-literals
+      - id: check-docstring-first
+      - id: check-executables-have-shebangs
       - id: check-merge-conflict
+      - id: check-symlinks
       - id: check-yaml
       - id: detect-private-key
       - id: end-of-file-fixer
+      - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.2
+    rev: 6.0.0
     hooks:
       - id: flake8
         args:
@@ -35,7 +39,7 @@ repos:
   #       args: [--no-strict-optional, --ignore-missing-imports]
   #       additional_dependencies: ["sqlalchemy-stubs"]
   - repo: https://github.com/packit/pre-commit-hooks
-    rev: 3bf9afc5ede12a4ee26e9451f306edf255749396
+    rev: 8db5a24e01b9f54aaa7a800f33c4b9aa619af1b9
     hooks:
       - id: check-rebase
         args:


### PR DESCRIPTION
Related to packit/deployment#396

- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter