### PR TITLE
Upgrade the base image to Fedora Linux 37

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-FROM fedora:35
+FROM registry.fedoraproject.org/fedora:37
 
 # Dependency of setupcfg2rpm
 RUN dnf install -y python3-packaging && dnf clean all


### PR DESCRIPTION
Be explicit about which registry the base image is pulled from, in order to avoid surprises.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>