### PR TITLE
Get ready to upgrade to PyGithub 1.58

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,20 @@ The logging level used can be configured by setting `LOG_LEVEL` to "info",
 For development purposes you can also use `flask run` to run the application.
 Before doing so:
 
+- Set up `config.py` and `private-key.pem` as described above.
 - Create and activate a Python virtual environment (with `mkvirtualenv tokman`, for example).
 - Install the app and the dependencies in the environment: `pip install -e .`
-- Configure flask for development mode: `export FLASK_ENV=development`.
+- Set up the database:
+
+```
+$ DB_URI=sqlite:////tmp/access_tokens.db alembic upgrade head
+```
+
+- Run flask with a command similar to this:
+
+```
+$ TOKMAN_CONFIG=$PWD/config.py flask --app tokman run --debug
+```
 
 [link]: https://docs.github.com/en/developers/apps/authenticating-with-github-apps#authenticating-as-a-github-app
 [installation tokens]: https://docs.github.com/en/rest/reference/apps#create-an-installation-access-token-for-an-app

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,3 +1,4 @@
+import os
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config
@@ -37,7 +38,7 @@ def run_migrations_offline():
     script output.
 
     """
-    url = config.get_main_option("sqlalchemy.url")
+    url = os.getenv("DB_URI") or config.get_main_option("sqlalchemy.url")
     context.configure(
         url=url,
         target_metadata=target_metadata,
@@ -56,8 +57,11 @@ def run_migrations_online():
     and associate a connection with the context.
 
     """
+    engine_config = config.get_section(config.config_ini_section)
+    if db_url := os.getenv("DB_URI"):
+        engine_config["sqlalchemy.url"] = db_url
     connectable = engine_from_config(
-        config.get_section(config.config_ini_section),
+        engine_config,
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,9 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development
 keywords =
     GitHub
@@ -35,7 +36,7 @@ install_requires =
     alembic
     pygithub
     cryptography
-python_requires = >=3.7
+python_requires = >=3.9
 include_package_data = True
 setup_requires =
     setuptools_scm

--- a/tokman/app.py
+++ b/tokman/app.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from flask import Flask, current_app
 from flask_sqlalchemy import SQLAlchemy
-from github import GithubIntegration
+from github import GithubIntegration, GithubException
 
 try:
     from flask_restx import Api, Resource
@@ -114,6 +114,11 @@ class AccessToken(Resource):
             except AppNotInstalledError as err:
                 api.logger.debug(f"Failed to get token for {repo}")
                 return {"error": f"Failed to retrieve a token: {err}"}, 400
+            except GithubException as err:
+                api.logger.debug(f"Failed to get token for {repo}")
+                return {
+                    "error": f"GithubException: {err.status} {err.data['message']}"
+                }, 400
 
         db.session.commit()
 


### PR DESCRIPTION
[PyGithub 1.58] introduces proper support for GitHub App auth. The old
interfaces are still available, but their behaviour changed:
get_installation() will raise a GithubException if the GitHub App is not
installed for a given repository, instead of returning None.

Make sure to catch this exception so that things don't brake when
PyGithub 1.58 lands (probably when upgrading the base image to Fedora
Linux 38).

[PyGithub 1.58]: https://github.com/PyGithub/PyGithub/releases/tag/v1.58.0