### PR TITLE
Don't install weak dependencies

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,7 +10,7 @@ WORKDIR /tokman
 ADD https://raw.githubusercontent.com/packit/deployment/master/scripts/setupcfg2rpm.py /tokman/setupcfg2rpm.py
 COPY setup.cfg /tokman/
 
-RUN dnf install -y \
+RUN dnf install -y --setopt=install_weak_deps=False \
     git \
     python3-gunicorn \
     python3-pip \


### PR DESCRIPTION
[python3-alembic](https://github.com/packit/tokman/blob/main/setup.cfg#L36) has a weak dependency on `python3-crypto` which is obsolete upstream and contains [critical vulnerability](https://bugzilla.redhat.com/show_bug.cgi?id=1409754#c4)