### PR TITLE
chore: remove ‹python3-certifi›

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -11,7 +11,7 @@ WORKDIR /tokman
 RUN dnf install -y --setopt=install_weak_deps=False \
     python3-flask-restx python3-pygithub python3-cryptography \
     git python3-gunicorn python3-alembic sqlite \
-    python3-blinker python3-certifi \
+    python3-blinker \
     && dnf clean all
 
 COPY . /tokman/


### PR DESCRIPTION
It should be pulled automatically by Sentry from
pip, C9S has dropped the package, so it's not
being maintained.

It has been also brought up a security vulnerability from the MP+ deployment.